### PR TITLE
feat: Homepage UI 퍼블리싱

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -23,6 +23,9 @@
     "?(*.)config.*",
     "server.{js,mjs}",
     ".next/**/*",
-    "src/utils/router.ts"
+    "src/utils/router.ts",
+    "src/components/BottomButton.tsx",
+    "src/components/Button.tsx",
+    "src/components/IconButton.tsx"
   ]
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from "react";
-import { Text } from "components/Text";
+import { fontStyle, Text } from "components/Text";
 import { Icon } from "components/Icon";
+import { Spacing } from "components/Spacing";
 
 const sizeStyle = {
   standard: { padding: "10px", width: "100px", height: "75px" },
@@ -8,15 +9,15 @@ const sizeStyle = {
 
 interface CardProps extends ComponentProps<"div"> {
   size?: "standard";
-  title?: string;
+  title: string;
   description?: string;
   thumbnail?: string;
 }
 
 export const Card = ({
   size = "standard",
-  title = "",
-  description = "",
+  title,
+  description,
   thumbnail = "questionMark",
   ...props
 }: CardProps) => {
@@ -30,11 +31,15 @@ export const Card = ({
       }}
       {...props}
     >
-      {description == null ? null : (
+      {description == null ? (
+        <Spacing size={fontStyle.subcation.fontSize} />
+      ) : (
         <Text typography="subcation">{description}</Text>
       )}
+      <Spacing size={4} />
       <Icon name={thumbnail} size={40} />
-      {title == null ? null : <Text typography="cation">{title}</Text>}
+      <Spacing size={8} />
+      <Text typography="cation">{title}</Text>
     </div>
   );
 };

--- a/src/components/Spacing.tsx
+++ b/src/components/Spacing.tsx
@@ -2,6 +2,7 @@ export const Spacing = ({ size }: { size: number | string }) => {
   return (
     <div
       css={{
+        flex: "none",
         width: "100%",
         height: typeof size === "number" ? `${size}px` : size,
       }}

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,7 +1,7 @@
 import { colors } from "constants/colors";
 import { ComponentProps } from "react";
 
-const fontStyle = {
+export const fontStyle = {
   title: { fontSize: "40px" },
   subtitle: { fontSize: "25px" },
   cation: { fontSize: "20px" },

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,74 +1,26 @@
-import { BottomButton } from "components/BottomButton";
-import { Button } from "components/Button";
 import { Card } from "components/Card";
 import { Flex } from "components/Flex";
 import { Icon } from "components/Icon";
-import { IconButton } from "components/IconButton";
 import { Spacing } from "components/Spacing";
 import { Text } from "components/Text";
-import { useState } from "react";
 
 export function HomePage() {
-  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
-  const [isIconButtonDisabled, setIsIconButtonDisabled] = useState(false);
-
   return (
     <>
-      <Text typography="title">미니쥬</Text>
-      <Icon name="nuleongSoobookz" size={40} />
-      <Card description="100점" title="순서 기억하기" thumbnail="pigFace" />
-      <Button
-        loading={isButtonDisabled}
-        onClick={() => {
-          setIsButtonDisabled(true);
-          setTimeout(() => {
-            setIsButtonDisabled(false);
-          }, 1500);
-        }}
-      >
-        일반 버튼
-      </Button>
-      <Spacing size={10} />
-      <Flex direction="column">
-        <Text typography="cation">아이콘버튼</Text>
-        <IconButton
-          name="nuleongSoobookz"
-          size={40}
-          onClick={() => {
-            setIsButtonDisabled(true);
-            setTimeout(() => {
-              setIsButtonDisabled(false);
-            }, 1500);
-          }}
-        />
+      <Spacing size={66} />
+      <Flex justify="center">
+        <Text typography="title">미니쥬</Text>
+        <Icon name="nuleongSoobookz" size={40} />
       </Flex>
-      <Spacing size={10} />
-      <Flex direction="column">
-        <Text typography="cation">아이콘버튼</Text>
-        <IconButton
-          name="pigFace"
-          size={40}
-          onClick={() => {
-            setIsIconButtonDisabled(true);
-            setTimeout(() => {
-              setIsIconButtonDisabled(false);
-            }, 1500);
-          }}
+      <Spacing size={155} />
+      <Flex>
+        <Card
+          title="순서 기억하기"
+          description="..점"
+          thumbnail="newlyHatchedChick"
         />
+        <Card title="???" thumbnail="questionMark" />
       </Flex>
-      <Card description="??점" title="????" />
-      <Icon name="nuleongSoobookz" width={100} height={100} />
-      <BottomButton
-        loading={isIconButtonDisabled}
-        onClick={() => {
-          setIsIconButtonDisabled(true);
-          setTimeout(() => {
-            setIsIconButtonDisabled(false);
-          }, 1500);
-        }}
-      >
-        게임 시작
-      </BottomButton>
     </>
   );
 }


### PR DESCRIPTION
## 🔍 변경사항

- 메인 Homepage UI 퍼블리싱
- src/components/Card.tsx
  - CardProps title 필수 값으로 변경
  - title, description props default 제거
  - `description == null`일 때 subcation 사이즈의 Spacing 컴포넌트 추가
  - description, Icon, title 사이 Spacing 컴포넌트 추가
  - title 필수로 받으므로 조건문 제거
- src/components/Spacing.tsx
  - 마진 병합 현상 방지를 위해 `flex: none` 추가
  
## 📷 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 before/after 캡처를 첨부해주세요 -->
<img width="568" height="1002" alt="image" src="https://github.com/user-attachments/assets/cabcbc06-b06e-4918-8068-c72a44c8aebe" />

## 📌 참고사항

<!-- 관련 이슈, 참고한 문서, 추가로 전달할 내용이 있다면 여기에 -->

<!-- 제목 형식
feat: 로그인 페이지 구현
fix: 토큰 만료시 자동 로그아웃 추가
refactor: 중복 요청 제거 및 에러 핸들링 개선
docs: 가이드 또는 추가 -->
