### PR TITLE
feat: Homepage 애니메이션 추가

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -26,6 +26,7 @@
     "src/utils/router.ts",
     "src/components/BottomButton.tsx",
     "src/components/Button.tsx",
-    "src/components/IconButton.tsx"
+    "src/components/IconButton.tsx",
+    "src/utils/assert.ts"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mini-zoo",
       "version": "0.1.0",
       "dependencies": {
+        "motion": "^12.23.6",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -254,7 +255,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
       "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -264,7 +265,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@emotion/react": {
@@ -3670,6 +3671,33 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.6.tgz",
+      "integrity": "sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.6",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4786,6 +4814,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.6.tgz",
+      "integrity": "sha512-6U55IW5i6Vut2ryKEhrZKg55490k9d6qdGXZoNSf98oQgDj5D7bqTnVJotQ6UW3AS6QfbW6KSLa7/e1gy+a07g==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.6.tgz",
+      "integrity": "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "find-deadcode": "npx knip --include=files,exports,types,nsExports,nsTypes --tags=-knipignore"
   },
   "dependencies": {
+    "motion": "^12.23.6",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/components/AnimationWrapper.tsx
+++ b/src/components/AnimationWrapper.tsx
@@ -1,0 +1,49 @@
+import { useAnimation } from "motion/react";
+import { ReactNode, useEffect } from "react";
+import { motion } from "motion/react";
+
+type AnimationType = "zoomIn" | "scaleOnTap";
+
+export function AnimationWrapper({
+  children,
+  type,
+}: {
+  children: ReactNode;
+  type: AnimationType;
+}) {
+  if (type === "zoomIn") {
+    return <ZoomInAnimation>{children}</ZoomInAnimation>;
+  }
+  if (type === "scaleOnTap") {
+    return <ScaleAnimation>{children}</ScaleAnimation>;
+  }
+
+  throw new Error("정의되지 않은 애니메이션 타입입니다");
+}
+
+function ZoomInAnimation({ children }: { children: ReactNode }) {
+  const controls = useAnimation();
+
+  useEffect(() => {
+    async function sequence() {
+      await controls.start({ scale: 2 }, { type: "spring" });
+      await controls.start({ scale: 1 }, { type: "spring" });
+    }
+
+    sequence();
+  }, [controls]);
+
+  return (
+    <motion.div initial={{ scale: 0.2 }} animate={controls}>
+      {children}
+    </motion.div>
+  );
+}
+
+function ScaleAnimation({ children }: { children: ReactNode }) {
+  return (
+    <motion.div whileHover={{ scale: 1.2 }} whileTap={{ scale: 0.8 }}>
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from "react";
 import { fontStyle, Text } from "components/Text";
 import { Icon } from "components/Icon";
 import { Spacing } from "components/Spacing";
+import { AnimationWrapper } from "./AnimationWrapper";
 
 const sizeStyle = {
   standard: { padding: "10px", width: "100px", height: "75px" },
@@ -22,24 +23,26 @@ export const Card = ({
   ...props
 }: CardProps) => {
   return (
-    <div
-      css={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        ...sizeStyle[size],
-      }}
-      {...props}
-    >
-      {description == null ? (
-        <Spacing size={fontStyle.subcation.fontSize} />
-      ) : (
-        <Text typography="subcation">{description}</Text>
-      )}
-      <Spacing size={4} />
-      <Icon name={thumbnail} size={40} />
-      <Spacing size={8} />
-      <Text typography="cation">{title}</Text>
-    </div>
+    <AnimationWrapper type="scaleOnTap">
+      <div
+        css={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          ...sizeStyle[size],
+        }}
+        {...props}
+      >
+        {description == null ? (
+          <Spacing size={fontStyle.subcation.fontSize} />
+        ) : (
+          <Text typography="subcation">{description}</Text>
+        )}
+        <Spacing size={4} />
+        <Icon name={thumbnail} size={40} />
+        <Spacing size={8} />
+        <Text typography="cation">{title}</Text>
+      </div>
+    </AnimationWrapper>
   );
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,3 +1,4 @@
+import { AnimationWrapper } from "components/AnimationWrapper";
 import { Card } from "components/Card";
 import { Flex } from "components/Flex";
 import { Icon } from "components/Icon";
@@ -8,10 +9,12 @@ export function HomePage() {
   return (
     <>
       <Spacing size={66} />
-      <Flex justify="center">
-        <Text typography="title">미니쥬</Text>
-        <Icon name="nuleongSoobookz" size={40} />
-      </Flex>
+      <AnimationWrapper type="zoomIn">
+        <Flex justify="center">
+          <Text typography="title">미니쥬</Text>
+          <Icon name="nuleongSoobookz" size={40} />
+        </Flex>
+      </AnimationWrapper>
       <Spacing size={155} />
       <Flex>
         <Card

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,14 @@
+export function assert(
+  condition: unknown,
+  message: string | Error
+): asserts condition {
+  if (condition) {
+    return;
+  }
+
+  if (typeof message === "string") {
+    throw new Error(message);
+  }
+
+  throw message;
+}


### PR DESCRIPTION
## 🔍 변경사항

- 추후 assert 사용을 위해 미리 assert 함수 만들어서 knip.json에 추가
- 애니메이션 사용을 위한 `"motion": "^12.23.6"` 라이브러리 추가
- 애니메이션 공통 컴포넌트 AnimationWrapper 추가
- Card 에 기본 탭 애니메이션 추가
- Homepage 제목에 애니메이션 추가

## 📷 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 before/after 캡처를 첨부해주세요 -->

https://github.com/user-attachments/assets/e5132bbf-a130-4924-9fc9-7da522ab0be2

## 📌 참고사항

<!-- 관련 이슈, 참고한 문서, 추가로 전달할 내용이 있다면 여기에 -->

<!-- 제목 형식
feat: 로그인 페이지 구현
fix: 토큰 만료시 자동 로그아웃 추가
refactor: 중복 요청 제거 및 에러 핸들링 개선
docs: 가이드 또는 추가 -->
