### PR TITLE
feat: 공통 컴포넌트 추가

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -23,6 +23,10 @@
     "?(*.)config.*",
     "server.{js,mjs}",
     ".next/**/*",
-    "src/utils/assert.ts"
+    "src/utils/assert.ts",
+    "src/components/ConfirmDialog.tsx",
+    "src/hooks/useConfirmDialog.tsx",
+    
+
   ]
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { GlobalStyle } from "components/GlobalStyle";
 import { Layout } from "components/Layout";
 import { PortalProvider } from "components/Portal";
+import { OverlayProvider } from "hooks/useOverlay";
 import type { AppProps } from "next/app";
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -8,9 +9,11 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <GlobalStyle>
         <PortalProvider>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
+          <OverlayProvider>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </OverlayProvider>
         </PortalProvider>
       </GlobalStyle>
     </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,17 @@
 import { GlobalStyle } from "components/GlobalStyle";
 import { Layout } from "components/Layout";
+import { PortalProvider } from "components/Portal";
 import type { AppProps } from "next/app";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <GlobalStyle>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <PortalProvider>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </PortalProvider>
       </GlobalStyle>
     </>
   );

--- a/src/components/AlertDialog.tsx
+++ b/src/components/AlertDialog.tsx
@@ -1,0 +1,58 @@
+import { Spacing } from "./Spacing";
+import { Portal } from "./Portal";
+import { Text } from "./Text";
+import { css } from "@emotion/react";
+import { colors } from "constants/colors";
+import { Button } from "./Button";
+import { Flex } from "./Flex";
+
+interface AlertDialogProps {
+  content: string;
+  open: boolean;
+  onConfirm: () => void;
+  confirmButtonText: string;
+}
+
+export function AlertDialog({
+  content,
+  open,
+  onConfirm,
+  confirmButtonText,
+}: AlertDialogProps) {
+  if (!open) return null;
+
+  return (
+    <Portal>
+      <div css={overlayStyle}>
+        <div css={dialogStyle}>
+          <Spacing size={36} />
+          <Flex justify="center">
+            <Text>{content}</Text>
+          </Flex>
+          <Spacing size={36} />
+          <Button onClick={onConfirm}>{confirmButtonText}</Button>
+        </div>
+      </div>
+    </Portal>
+  );
+}
+
+const overlayStyle = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const dialogStyle = css`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: ${colors.peach50};
+  padding: 24px;
+  border-radius: 16px;
+  width: 75%;
+`;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -12,7 +12,6 @@ export interface ButtonProps extends ComponentProps<"button"> {
 
 export function Button({
   children,
-
   loading = false,
   onClick,
   disableHover = true,

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,76 @@
+import { Spacing } from "./Spacing";
+import { Portal } from "./Portal";
+import { Text } from "./Text";
+import { css } from "@emotion/react";
+import { colors } from "constants/colors";
+import { Button } from "./Button";
+import { Flex } from "./Flex";
+
+interface ConfirmDialogProps {
+  content?: string;
+  open: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  rejectButtonText: string;
+  confirmButtonText: string;
+}
+
+export function ConfirmDialog({
+  content,
+  open,
+  onConfirm,
+  onClose,
+  rejectButtonText = "취소",
+  confirmButtonText = "확인",
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <Portal>
+      <div css={overlayStyle}>
+        <div css={dialogStyle}>
+          <Spacing size={36} />
+          <Flex justify="center">
+            <Text>{content}</Text>
+          </Flex>
+          <Spacing size={36} />
+          <Flex gap={16} justify="center">
+            <div css={{ flex: 1 }}>
+              <Button
+                onClick={onClose}
+                css={{
+                  backgroundColor: colors.brown300,
+                }}
+              >
+                {rejectButtonText}
+              </Button>
+            </div>
+            <div css={{ flex: 1 }}>
+              <Button onClick={onConfirm}>{confirmButtonText}</Button>
+            </div>
+          </Flex>
+        </div>
+      </div>
+    </Portal>
+  );
+}
+
+const overlayStyle = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const dialogStyle = css`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: ${colors.peach50};
+  padding: 24px;
+  border-radius: 16px;
+  width: 75%;
+`;

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,58 @@
+import {
+  Children,
+  ReactNode,
+  RefObject,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+
+type RootNode = ShadowRoot | Document | Node;
+
+interface PortalProps {
+  children: ReactNode;
+  disabled?: boolean | undefined;
+  container?: RefObject<HTMLElement> | null | undefined;
+}
+
+export default function Portal({ children, disabled, container }: PortalProps) {
+  const [resolvedContainer, setResolvedContainer] = useState(
+    container?.current
+  );
+
+  useEffect(() => {
+    setResolvedContainer(() => container?.current);
+  }, [container]);
+
+  const isServer = useSyncExternalStore(
+    () => () => {},
+    () => false, // Client
+    () => true // Server
+  );
+
+  if (isServer || disabled) {
+    return <>{children}</>;
+  }
+
+  const mountNode = resolvedContainer ?? getPortalNode(() => document);
+
+  return (
+    <>{Children.map(children, (child) => createPortal(child, mountNode))}</>
+  );
+}
+
+const getPortalNode = (cb: () => RootNode) => {
+  const node = cb?.();
+  const rootNode = node.getRootNode();
+  if (isShadowRoot(rootNode)) return rootNode;
+  return getDocument(node).body;
+};
+
+function isShadowRoot(node: unknown): node is ShadowRoot {
+  return typeof ShadowRoot !== "undefined" && node instanceof ShadowRoot;
+}
+
+function getDocument(node: Node): Document {
+  return node?.ownerDocument ?? document;
+}

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -3,8 +3,8 @@ import { ComponentProps } from "react";
 
 export const fontSize = {
   t1: "40px",
-  t2: "20px",
-  t3: "15px",
+  t2: "24px",
+  t3: "16px",
 } as const;
 
 type Typography = keyof typeof fontSize;

--- a/src/hooks/useAlertDialog.tsx
+++ b/src/hooks/useAlertDialog.tsx
@@ -1,0 +1,30 @@
+import { AlertDialog } from "components/AlertDialog";
+import { useOverlay } from "./useOverlay";
+
+export const useAlertDialog = () => {
+  const overlay = useOverlay();
+
+  return {
+    open: ({
+      content,
+      confirmButtonText,
+    }: {
+      content: string;
+      confirmButtonText: string;
+    }) => {
+      return new Promise<boolean>((resolve) => {
+        overlay.open(({ isOpen, close }) => (
+          <AlertDialog
+            content={content}
+            open={isOpen}
+            onConfirm={() => {
+              close();
+              resolve(true);
+            }}
+            confirmButtonText={confirmButtonText}
+          />
+        ));
+      });
+    },
+  };
+};

--- a/src/hooks/useConfirmDialog.tsx
+++ b/src/hooks/useConfirmDialog.tsx
@@ -1,0 +1,37 @@
+import { ConfirmDialog } from "components/ConfirmDialog";
+import { useOverlay } from "./useOverlay";
+
+export const useConfirmDialog = () => {
+  const overlay = useOverlay();
+
+  return {
+    open: ({
+      content,
+      rejectButtonText,
+      confirmButtonText,
+    }: {
+      content: string;
+      rejectButtonText: string;
+      confirmButtonText: string;
+    }) => {
+      return new Promise<boolean>((resolve) => {
+        overlay.open(({ isOpen, close }) => (
+          <ConfirmDialog
+            content={content}
+            open={isOpen}
+            onClose={() => {
+              resolve(false);
+              close();
+            }}
+            onConfirm={() => {
+              resolve(true);
+              close();
+            }}
+            rejectButtonText={rejectButtonText}
+            confirmButtonText={confirmButtonText}
+          />
+        ));
+      });
+    },
+  };
+};

--- a/src/hooks/useOverlay.tsx
+++ b/src/hooks/useOverlay.tsx
@@ -1,0 +1,158 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+  useContext,
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  Ref,
+  forwardRef,
+} from "react";
+
+let elementId = 1;
+
+interface Options {
+  exitOnUnmount?: boolean;
+}
+
+export function useOverlay({ exitOnUnmount = true }: Options = {}) {
+  const context = useContext(OverlayContext);
+
+  if (context == null) {
+    throw new Error("useOverlay is only available within OverlayProvider.");
+  }
+
+  const { mount, unmount } = context;
+  const [id] = useState(() => String(elementId++));
+
+  const overlayRef = useRef<OverlayControlRef | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (exitOnUnmount) {
+        unmount(id);
+      }
+    };
+  }, [exitOnUnmount, id, unmount]);
+
+  return useMemo(
+    () => ({
+      open: (
+        overlayElement: React.ComponentType<{
+          isOpen: boolean;
+          close: () => void;
+          onExit: () => void;
+          exit: () => void;
+        }>
+      ) => {
+        mount(
+          id,
+          <OverlayController
+            key={Date.now()}
+            ref={overlayRef}
+            overlayElement={overlayElement}
+            onExit={() => {
+              unmount(id);
+            }}
+          />
+        );
+      },
+      close: () => {
+        overlayRef.current?.close();
+      },
+      exit: () => {
+        unmount(id);
+      },
+    }),
+    [id, mount, unmount]
+  );
+}
+
+interface Props {
+  overlayElement: React.ComponentType<{
+    isOpen: boolean;
+    close: () => void;
+    onExit: () => void;
+    exit: () => void;
+  }>;
+  onExit: () => void;
+}
+
+interface OverlayControlRef {
+  close: () => void;
+}
+
+const OverlayController = forwardRef(function OverlayController(
+  { overlayElement: OverlayElement, onExit }: Props,
+  ref: Ref<OverlayControlRef>
+) {
+  const [isOpenOverlay, setIsOpenOverlay] = useState(false);
+
+  const handleOverlayClose = useCallback(() => setIsOpenOverlay(false), []);
+
+  useImperativeHandle(
+    ref,
+    () => {
+      return { close: handleOverlayClose };
+    },
+    [handleOverlayClose]
+  );
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      setIsOpenOverlay(true);
+    });
+  }, []);
+
+  return (
+    <OverlayElement
+      isOpen={isOpenOverlay}
+      close={handleOverlayClose}
+      onExit={onExit}
+      exit={onExit}
+    />
+  );
+});
+
+const OverlayContext = createContext<{
+  mount(id: string, element: ReactNode): void;
+  unmount(id: string): void;
+} | null>(null);
+if (process.env.NODE_ENV !== "production") {
+  OverlayContext.displayName = "OverlayContext";
+}
+
+export function OverlayProvider({ children }: { children: ReactNode }) {
+  const [overlayById, setOverlayById] = useState<Map<string, ReactNode>>(
+    new Map()
+  );
+  const mount = useCallback((id: string, element: ReactNode) => {
+    setOverlayById((overlayById) => {
+      const cloned = new Map(overlayById);
+      cloned.set(id, element);
+      return cloned;
+    });
+  }, []);
+
+  const unmount = useCallback((id: string) => {
+    setOverlayById((overlayById) => {
+      const cloned = new Map(overlayById);
+      cloned.delete(id);
+      return cloned;
+    });
+  }, []);
+
+  const context = useMemo(() => ({ mount, unmount }), [mount, unmount]);
+
+  return (
+    <OverlayContext.Provider value={context}>
+      {children}
+      {[...overlayById.entries()].map(([id, element]) => (
+        <div key={id}>{element}</div>
+      ))}
+    </OverlayContext.Provider>
+  );
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -5,12 +5,20 @@ import { Flex } from "components/Flex";
 import { Icon } from "components/Icon";
 import { Spacing } from "components/Spacing";
 import { Text } from "components/Text";
+import { useAlertDialog } from "hooks/useAlertDialog";
 import { useRouter } from "next/router";
 import { sequenceMemoryGameScoreStorage } from "pages/sequence-memory-game/common/utils/score-storage";
 import { RouteUrls } from "utils/router";
 
 export function HomePage() {
-  const router = useRouter();
+  const alertDialog = useAlertDialog();
+
+  const handleComingSoonClick = async () => {
+    await alertDialog.open({
+      content: "다음 게임을 준비 중이에요",
+      confirmButtonText: "확인",
+    });
+  };
 
   return (
     <>
@@ -37,7 +45,7 @@ export function HomePage() {
         <Card
           title="???"
           thumbnail="questionMark"
-          onClick={() => router.push(RouteUrls.test())}
+          onClick={handleComingSoonClick}
         />
       </Flex>
     </>


### PR DESCRIPTION
## 🔍 변경사항

- useOverlay, useConfirmDialog, useAlertDialog 훅 추가
- Portal, ConfirmDialog, AlertDialog 공통 컴포넌트 추가
- ConfirmDialog, useConfirmDialog 은 아직 사용하지 않아서 knip에 추가
- Text 컴포넌트 t2, t3 폰트 사이즈 변경
- 홈페이지 물음표 버튼 누르면 '다음 게임을 준비 중이에요' 알람 나오도록 추가

## 📷 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 before/after 캡처를 첨부해주세요 -->
<img width="550" height="983" alt="image" src="https://github.com/user-attachments/assets/bd6c57a4-3d62-4632-9785-ff5d9cb8f273" />


## 📌 참고사항

<!-- 관련 이슈, 참고한 문서, 추가로 전달할 내용이 있다면 여기에 -->
- useOverlay는 @toss/slash 에 있는 코드 참고함.
  리액트 18버전까지만 지원해서 라이브러리를 설치하지 않고 만들어서 사용함.

<!-- 제목 형식
feat: 로그인 페이지 구현
fix: 토큰 만료시 자동 로그아웃 추가
refactor: 중복 요청 제거 및 에러 핸들링 개선
docs: 가이드 또는 추가 -->
