### PR TITLE
perf: 이모지 이미지 응답 헤더 Cache-Control max-age 1년으로 설정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,19 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
+  headers: async () => {
+    return [
+      {
+        source: "/emoji/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 🔍 변경사항

-  받아온 이미지를 캐싱하지 않고 화면에 접속할 때마다 이모지 이미지를 새로 다운 받아서 불필요한 네트워크 요청으로 인해 로딩 성능 저하
    - 이모지 이미지 응답 헤더 Cache-Control max-age 1년으로 설정
    - 받아온 이미지에 대해서는 다시 요청하지 않고 디스크 캐시에 있는 이미지를 사용하게 변경

## 📷 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 before/after 캡처를 첨부해주세요 -->

## 📌 참고사항

<!-- 관련 이슈, 참고한 문서, 추가로 전달할 내용이 있다면 여기에 -->

<!-- 제목 형식
feat: 로그인 페이지 구현
fix: 토큰 만료시 자동 로그아웃 추가
refactor: 중복 요청 제거 및 에러 핸들링 개선
docs: 가이드 또는 추가 -->
