### PR TITLE
perf: 다음 페이지의 js번들을 프리페치하여 화면전환 속도를 빠르게 함

### DIFF
--- a/src/hooks/usePrefetchPages.ts
+++ b/src/hooks/usePrefetchPages.ts
@@ -1,0 +1,10 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+export const usePrefetchPages = (pages: string[]) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    pages.forEach((page) => router.prefetch(page));
+  }, [router, pages]);
+};

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -6,6 +6,7 @@ import { Icon } from "components/Icon";
 import { Spacing } from "components/Spacing";
 import { Text } from "components/Text";
 import { useAlertDialog } from "hooks/useAlertDialog";
+import { usePrefetchPages } from "hooks/usePrefetchPages";
 import { useRouter } from "next/router";
 import { sequenceMemoryGameScoreStorage } from "pages/sequence-memory-game/common/utils/score-storage";
 import { RouteUrls } from "utils/router";
@@ -54,6 +55,7 @@ export function HomePage() {
 
 function SequenceMemoryGameCard() {
   const router = useRouter();
+  usePrefetchPages([RouteUrls.sequenceMemoryGame.intro()]);
 
   return (
     <Card

--- a/src/pages/sequence-memory-game/intro/index.tsx
+++ b/src/pages/sequence-memory-game/intro/index.tsx
@@ -8,9 +8,14 @@ import { Text } from "components/Text";
 import { useRouter } from "next/router";
 import { RouteUrls } from "utils/router";
 import { sequenceMemoryGameScoreStorage } from "../common/utils/score-storage";
+import { usePrefetchPages } from "hooks/usePrefetchPages";
 
 export function SequenceMemoryGameIntroPage() {
   const router = useRouter();
+  usePrefetchPages([
+    RouteUrls.sequenceMemoryGame.tutorial.index(),
+    RouteUrls.sequenceMemoryGame.playing(),
+  ]);
 
   return (
     <>

--- a/src/pages/sequence-memory-game/playing/index.tsx
+++ b/src/pages/sequence-memory-game/playing/index.tsx
@@ -26,11 +26,13 @@ import { AnimationWrapper } from "components/AnimationWrapper";
 import { getRandomItem } from "utils/random";
 import { effects } from "../common/constants/appearanceEffects";
 import { getIconCountByLevel } from "./common/utils/gameSetting";
+import { usePrefetchPages } from "hooks/usePrefetchPages";
 
 export function SequenceMemoryGamePlayingPage() {
   const [level, setLevel] = useState<number>(1);
   const [score, setScore] = useState(0);
   const router = useRouter();
+  usePrefetchPages([RouteUrls.home()]);
 
   return (
     <>

--- a/src/pages/sequence-memory-game/tutorial/answer.tsx
+++ b/src/pages/sequence-memory-game/tutorial/answer.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/router";
 import { RouteUrls } from "utils/router";
 import { chunk } from "es-toolkit";
 import { DottedBox } from "pages/sequence-memory-game/common/components/DottedBox";
+import { usePrefetchPages } from "hooks/usePrefetchPages";
 
 export const SequenceMemoryGameTutorialAnswer = () => {
   const [tutorialFlow, setTutorialFlow] = useState<
@@ -24,6 +25,7 @@ export const SequenceMemoryGameTutorialAnswer = () => {
   >("INITIAL");
 
   const router = useRouter();
+  usePrefetchPages([RouteUrls.sequenceMemoryGame.playing()]);
 
   return (
     <>

--- a/src/pages/sequence-memory-game/tutorial/index.tsx
+++ b/src/pages/sequence-memory-game/tutorial/index.tsx
@@ -6,9 +6,11 @@ import { Text } from "components/Text";
 import { SequenceMemoryGameTutorialGame } from "./components/tutorialGame";
 import { useRouter } from "next/router";
 import { RouteUrls } from "utils/router";
+import { usePrefetchPages } from "hooks/usePrefetchPages";
 
 export function SequenceMemoryGameTutorialPage() {
   const router = useRouter();
+  usePrefetchPages([RouteUrls.sequenceMemoryGame.tutorial.answer()]);
 
   return (
     <>


### PR DESCRIPTION
## 🔍 변경사항

- 다음 페이지의 js번들을 프리페치하여 화면전환 속도를 빠르게 했습니다.

## 📷 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 before/after 캡처를 첨부해주세요 -->

## 📌 참고사항

<!-- 관련 이슈, 참고한 문서, 추가로 전달할 내용이 있다면 여기에 -->

<!-- 제목 형식
feat: 로그인 페이지 구현
fix: 토큰 만료시 자동 로그아웃 추가
refactor: 중복 요청 제거 및 에러 핸들링 개선
docs: 가이드 또는 추가 -->
